### PR TITLE
Fix overFlow of the rotating logo beyond teh navbar possibly caused due to optimisation

### DIFF
--- a/src/components/Navbar/index.js
+++ b/src/components/Navbar/index.js
@@ -37,7 +37,11 @@ const Navbar = () => {
     <NavWrapper>
       <nav className={click ? "navbar1" : "navbar"}>
         <Link to="/" className="navbar-logo" onClick={closeMobileMenu}>
-          <img src={ACMnav} className="acm-logo" style={{ width: "50%" }} />
+          <img
+            src={ACMnav}
+            className="acm-logo"
+            style={{ width: "50%", height: "125px" }}
+          />
         </Link>
         <div className="menu-icon" onClick={handleClick}>
           <i className={click ? "fas fa-times" : "fas fa-bars"} />


### PR DESCRIPTION
Fix overFlow of the rotating logo beyond teh navbar possibly caused due to optimisation

BEFORE CHANGE:-

![image](https://user-images.githubusercontent.com/59202075/128679593-640ba8b2-54b1-450c-bdac-1b842fdc591f.png)


AFTER CHANGE:-

![image](https://user-images.githubusercontent.com/59202075/128679718-576429d9-59d1-43e1-a210-6e1a03bd4083.png)



