### PR TITLE
Added website link to hactoberfest block on the Event timeline

### DIFF
--- a/src/components/Timeline/index.js
+++ b/src/components/Timeline/index.js
@@ -19,6 +19,14 @@ const Timeline = () => {
           <div className="event-content">
             <h3>Hacktoberfest 2021</h3>
             <p>Opened ACM BITS Goa Website for Hacktoberfest 2021</p>
+            <a
+              target="_blank"
+              href="https://github.com/ACM-BITS-Pilani-Goa/OfficialWebsite"
+              rel="noreferrer"
+            >
+              <br />
+              Check it out!
+            </a>
           </div>
         </VerticalTimelineElement>
         <VerticalTimelineElement


### PR DESCRIPTION
Added website link to hactoberfest block on the Event timeline

![image](https://user-images.githubusercontent.com/59202075/140858292-046478b6-fe92-4c73-ba43-12dc0c743f36.png)
